### PR TITLE
Remove version requirement from the cmake modules

### DIFF
--- a/kicad-mac-builder/docs.cmake
+++ b/kicad-mac-builder/docs.cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
-
 set( DOCS_OUTPUT_DIR ${CMAKE_BINARY_DIR}/docs/help)
 
 ExternalProject_Add(

--- a/kicad-mac-builder/footprints.cmake
+++ b/kicad-mac-builder/footprints.cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
-
 ExternalProject_Add(
         footprints
         PREFIX  footprints

--- a/kicad-mac-builder/kicad.cmake
+++ b/kicad-mac-builder/kicad.cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
-
 include (ExternalProject)
 
 ExternalProject_Add(

--- a/kicad-mac-builder/package_extras.cmake
+++ b/kicad-mac-builder/package_extras.cmake
@@ -1,6 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
-
-
 # I don't like how I have to recreate <BINARY_DIR> of other targets here,
 # but I didn't like it when the install aspect of this installed it into a temp directory either
 # Maybe a better long term solution is to actually mount the DMG before we do this, and install directly into the DMG

--- a/kicad-mac-builder/package_kicad.cmake
+++ b/kicad-mac-builder/package_kicad.cmake
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
-
-
-
 ExternalProject_Add(
         package-kicad
         DEPENDS kicad symbols translations docs footprints templates

--- a/kicad-mac-builder/packages3d.cmake
+++ b/kicad-mac-builder/packages3d.cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
-
 ExternalProject_Add(
         packages3d
         PREFIX  packages3d

--- a/kicad-mac-builder/python.cmake
+++ b/kicad-mac-builder/python.cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
-
 include (ExternalProject)
 
 ExternalProject_Add(

--- a/kicad-mac-builder/symbols.cmake
+++ b/kicad-mac-builder/symbols.cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
-
 ExternalProject_Add(
         symbols
         PREFIX  symbols

--- a/kicad-mac-builder/templates.cmake
+++ b/kicad-mac-builder/templates.cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
-
 ExternalProject_Add(
         templates
         PREFIX  templates

--- a/kicad-mac-builder/translations.cmake
+++ b/kicad-mac-builder/translations.cmake
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
 include (ExternalProject)
 
 ExternalProject_Add(

--- a/kicad-mac-builder/wxpython.cmake
+++ b/kicad-mac-builder/wxpython.cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.8)
-
 include (ExternalProject)
 
 ExternalProject_Add(


### PR DESCRIPTION
This is already specified in the main CMakeLists. The modules are never
intended to be used with anything else, so lets just have the version
requirement there.