### PR TITLE
Fixup pcbnew.so and other libraries

### DIFF
--- a/kicad-mac-builder/bin/fixup-pcbnew-so.sh
+++ b/kicad-mac-builder/bin/fixup-pcbnew-so.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Many thanks to metacollin.
+
+if [ $# -ne 1 ] ; then
+   echo "bad number of arguments, must pass Frameworks directory"
+   exit 1
+fi
+
+if [ ! -d "$1/python/site-packages" ]; then
+   echo "$1/python/site-packages doesn't appear to exist.  exiting."
+   exit 1
+fi
+
+cd "$1"
+
+for file in *.dylib; do
+    fixup_libs=($(otool -L $file | grep -o "@executable_path.*.dylib"));
+    libs=($(echo ${fixup_libs[@]} | grep -o "[^/]*dylib"));
+    for ((i=0;i<${#fixup_libs[@]};++i)); do
+        install_name_tool -change "${fixup_libs[i]}" "@rpath/${libs[i]}" $file;
+    done;
+    install_name_tool -add_rpath @loader_path/../.. -add_rpath @executable_path/../Frameworks $file;
+done;
+
+cd python/site-packages
+
+fixup_libs=($(otool -L _pcbnew.so | grep -o "@executable_path.*.dylib"));
+libs=($(echo ${fixup_libs[@]} | grep -o "[^/]*dylib"));
+for ((i=0;i<${#fixup_libs[@]};++i)); do
+    install_name_tool -change "${fixup_libs[i]}" "@rpath/${libs[i]}" _pcbnew.so;
+done
+
+install_name_tool -add_rpath @loader_path/../.. -add_rpath @executable_path/../Frameworks _pcbnew.so
+
+echo "done"

--- a/kicad-mac-builder/kicad.cmake
+++ b/kicad-mac-builder/kicad.cmake
@@ -65,12 +65,3 @@ ExternalProject_Add_Step(
         DEPENDEES install
         COMMAND ${BIN_DIR}/fixup-pcbnew-so.sh  ${KICAD_INSTALL_DIR}/kicad.app/Contents/Frameworks/
 )
-
-ExternalProject_Add_Step(
-        kicad
-        verify-pcbnew-so
-        COMMENT "Checking the importing of pcbnew"
-        DEPENDEES fixup-pcbnew-so
-        WORKING_DIRECTORY ${KICAD_INSTALL_DIR}/kicad.app/Contents/Frameworks/python/site-packages/
-        COMMAND ${KICAD_INSTALL_DIR}/kicad.app/Contents/Frameworks/Python.framework/Versions/Current/bin/python -m pcbnew
-)

--- a/kicad-mac-builder/kicad.cmake
+++ b/kicad-mac-builder/kicad.cmake
@@ -71,6 +71,6 @@ ExternalProject_Add_Step(
         verify-pcbnew-so
         COMMENT "Checking the importing of pcbnew"
         DEPENDEES fixup-pcbnew-so
-        WORKING_DIR ${KICAD_INSTALL_DIR}/kicad.app/Contents/Frameworks/python/site-packages/
+        WORKING_DIRECTORY ${KICAD_INSTALL_DIR}/kicad.app/Contents/Frameworks/python/site-packages/
         COMMAND ${KICAD_INSTALL_DIR}/kicad.app/Contents/Frameworks/Python.framework/Versions/Current/bin/python -m pcbnew
 )

--- a/kicad-mac-builder/kicad.cmake
+++ b/kicad-mac-builder/kicad.cmake
@@ -57,3 +57,20 @@ ExternalProject_Add_Step(
         DEPENDEES install
         COMMAND cp ${six_DIR}/six.py ${KICAD_INSTALL_DIR}/kicad.app/Contents/Frameworks/python/site-packages/
 )
+
+ExternalProject_Add_Step(
+        kicad
+        fixup-pcbnew-so
+        COMMENT "Fixing loader dependencies so _pcbnew.so works both internal and external to KiCad."
+        DEPENDEES install
+        COMMAND ${BIN_DIR}/fixup-pcbnew-so.sh  ${KICAD_INSTALL_DIR}/kicad.app/Contents/Frameworks/
+)
+
+ExternalProject_Add_Step(
+        kicad
+        verify-pcbnew-so
+        COMMENT "Checking the importing of pcbnew"
+        DEPENDEES fixup-pcbnew-so
+        WORKING_DIR ${KICAD_INSTALL_DIR}/kicad.app/Contents/Frameworks/python/site-packages/
+        COMMAND ${KICAD_INSTALL_DIR}/kicad.app/Contents/Frameworks/Python.framework/Versions/Current/bin/python -m pcbnew
+)


### PR DESCRIPTION
This lets us imported pcbnew from external python.  Fixes #77.