### PR TITLE
Make sure KiCad updates from upstream every build.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 KiCad Mac Builder
 =================
 
-This is the 2017+ KiCad Mac builder and packager.  It does not yet work.  Do not use it to build or package.
-
-It's close, though.
+This is the 2017+ KiCad Mac builder and packager.  It does not yet work.  Do not use it to build or package.  It's close, though.
 
 This supports macOS 10.11, 10.12, and 10.13.
 

--- a/kicad-mac-builder/CMakeLists.txt
+++ b/kicad-mac-builder/CMakeLists.txt
@@ -26,7 +26,7 @@ set( ngspice_INSTALL_DIR ${CMAKE_BINARY_DIR}/ngspice-dest )
 include( ngspice.cmake)
 
 set( KICAD_URL https://git.launchpad.net/kicad )
-set( KICAD_TAG master )
+set( KICAD_TAG origin/master )
 set( KICAD_INSTALL_DIR ${CMAKE_BINARY_DIR}/kicad-dest )
 
 # find OCE

--- a/kicad-mac-builder/kicad.cmake
+++ b/kicad-mac-builder/kicad.cmake
@@ -6,8 +6,11 @@ ExternalProject_Add(
         DEPENDS python wxpython wxwidgets six ngspice
         GIT_REPOSITORY ${KICAD_URL}
         GIT_TAG ${KICAD_TAG}
-        UPDATE_COMMAND      ""
-        PATCH_COMMAND       ${BIN_DIR}/git-multipatch.sh ${CMAKE_SOURCE_DIR}/patches/kicad/*.patch
+        UPDATE_COMMAND          git fetch
+        COMMAND                 echo "Making sure we aren't in the middle of a crashed git-am"
+        COMMAND                 git am --abort || true
+        COMMAND                 git reset --hard ${KICAD_TAG}
+        COMMAND                 ${BIN_DIR}/git-multipatch.sh ${CMAKE_SOURCE_DIR}/patches/kicad/*.patch
         CMAKE_ARGS  ${KICAD_CMAKE_ARGS}
 )
 

--- a/kicad-mac-builder/wxpython.cmake
+++ b/kicad-mac-builder/wxpython.cmake
@@ -24,6 +24,7 @@ ExternalProject_Add(
                             --with-macosx-version-min=${MACOS_MIN_VERSION}
                             CC=clang
                             CXX=clang++
+        UPDATE_COMMAND ""
         BUILD_COMMAND ${MAKE}
         BUILD_IN_SOURCE 1
 )


### PR DESCRIPTION
Fix wxwidgets configuring and updating every build.

I've made a bunch of changes from some investigations prompted by nickoe.

KiCad will now update when you build, and it will apply the KiCad patches on the top.

You can see it in the terminal like this:

[ 79%] Performing update step for 'kicad'
cd /Users/wolf/wnl/kicad/kicad-mac-builder/build/kicad/src/kicad && git fetch
cd /Users/wolf/wnl/kicad/kicad-mac-builder/build/kicad/src/kicad && echo "Making sure we aren't in the middle of a crashed git-am"
Making sure we aren't in the middle of a crashed git-am
cd /Users/wolf/wnl/kicad/kicad-mac-builder/build/kicad/src/kicad && git am --abort || true
cd /Users/wolf/wnl/kicad/kicad-mac-builder/build/kicad/src/kicad && git reset --hard origin/master
HEAD is now at b0b5d9139 pcbnew: fix OpenMP synch issue
cd /Users/wolf/wnl/kicad/kicad-mac-builder/build/kicad/src/kicad && /Users/wolf/wnl/kicad/kicad-mac-builder/kicad-mac-builder/bin/git-multipatch.sh "/Users/wolf/wnl/kicad/kicad-mac-builder/kicad-mac-builder/patches/kicad/*.patch"
/Users/wolf/wnl/kicad/kicad-mac-builder/kicad-mac-builder/patches/kicad/0001-Setup-PYTHON_FRAMEWORK-embedded-in-MacOS.patch
Applying: Setup PYTHON_FRAMEWORK embedded in MacOS.
/Users/wolf/wnl/kicad/kicad-mac-builder/kicad-mac-builder/patches/kicad/2-0001-Backported-BundleUtilities-and-GetPrerequisites-from.patch
Applying: Backported BundleUtilities and GetPrerequisites from Cmake 3.11.1 to let macOS packaging work at least back to 3.6.2.
/Users/wolf/wnl/kicad/kicad-mac-builder/kicad-mac-builder/patches/kicad/3-0001-Fixup-ngspice-library-when-bundling-on-macOS.patch
Applying: Fixup ngspice library when bundling on macOS.
[ 81%] Performing configure step for 'kicad'

I also set wxwidgets not to update.

Fixes #48.  Fixes #161.  Fixes #162.